### PR TITLE
fix: Correct image filename case for Ashish Sharma in FacultyProfiles…

### DIFF
--- a/src/components/home/DepartmentWiseData/Eecomponents/FacultyProfiles.js
+++ b/src/components/home/DepartmentWiseData/Eecomponents/FacultyProfiles.js
@@ -28,7 +28,7 @@ const FacultyProfiles = () => {
       name: 'Er. Ashish Sharma',
       qualification: 'B.Tech., M.Tech.',
       expertise: 'Antenna & Wave Propagation, Instrumentation, Sensors',
-      image: '/images/ee/ashish_sharma.png', // Add image path when available
+      image: '/images/ee/Ashish_sharma.png', // Add image path when available
     },
     {
       name: 'Er. Rishabh Upadhyay',


### PR DESCRIPTION
This pull request updates the `FacultyProfiles` component to include image paths for faculty members in the Electrical Engineering department. The changes ensure that the faculty profiles now display corresponding images.

Key change:

* Updated the `image` property for four faculty members (`Dr. D. Shakina Deiv`, `Dr. Mayank Pratap Singh`, `Er. Ashish Sharma`, and `Er. Rishabh Upadhyay`) in the `FacultyProfiles` component to include the correct image paths.